### PR TITLE
Fix realtime graph

### DIFF
--- a/lib/blocs/dashboard/realtime_statistics_bloc.dart
+++ b/lib/blocs/dashboard/realtime_statistics_bloc.dart
@@ -12,15 +12,35 @@ class RealtimeStatisticsBloc extends DashboardBaseBloc<List<AccountBlock>> {
     int chainHeight = (await zenon!.ledger.getFrontierMomentum()).height;
     int height = chainHeight - kMomentumsPerWeek > 0
         ? chainHeight - kMomentumsPerWeek
-        : 2;
-    List<AccountBlock> response = (await zenon!.ledger.getAccountBlocksByHeight(
+        : 1;
+    int pageIndex = 0;
+    int pageSize = 10;
+    bool isLastPage = false;
+    List<AccountBlock> blockList = [];
+
+    while (!isLastPage) {
+        List<AccountBlock> response = (await zenon!.ledger.getAccountBlocksByPage(
           Address.parse(kSelectedAddress!),
-          height == 0 ? 0 : height - 1,
+          pageIndex: pageIndex,
+          pageSize: pageSize,
         ))
-            .list ??
-        [];
-    if (response.isNotEmpty) {
-      return response;
+          .list ??
+          [];
+        
+        if (response.isEmpty)
+            break;
+
+        blockList.addAll(response);
+
+        if (response.last.confirmationDetail!.momentumHeight <= height)
+            break;
+
+        pageIndex += 1;
+        isLastPage = response.length < pageSize;
+    }
+
+    if (blockList.isNotEmpty) {
+      return blockList;
     } else {
       throw 'No available data';
     }


### PR DESCRIPTION
# Problem

Realtime stats are calculated on last week account blocks. Account blocks are retrieved by account block height. The momentum height is calculated using the frontier momentum height minus a fixed momentums per week constant of 60480. The calculated momentum height cannot be used to retrieve the last week account blocks and will always return an empty result.

# Solution

Page through the account blocks until the momentum height of the confirmation detail is smaller than or equal to the calculated momentum height.

# Things to know

1. The paging uses a static page size of 10.