### PR TITLE
Fix fusing address reset

### DIFF
--- a/lib/widgets/modular_widgets/plasma_widgets/plasma_options/plasma_options.dart
+++ b/lib/widgets/modular_widgets/plasma_widgets/plasma_options/plasma_options.dart
@@ -188,7 +188,8 @@ class _PlasmaOptionsState extends State<PlasmaOptions> {
                         child: InputField(
                           enabled: _maxQsrAmount! > 0,
                           onChanged: (String value) {
-                            setState(() {});
+                            // The setState() causes a redraw which resets the beneficiaryAddress.
+                            // setState(() {});
                           },
                           inputFormatters:
                               FormatUtils.getPlasmaAmountTextInputFormatters(

--- a/lib/widgets/modular_widgets/plasma_widgets/plasma_options/plasma_options.dart
+++ b/lib/widgets/modular_widgets/plasma_widgets/plasma_options/plasma_options.dart
@@ -55,7 +55,9 @@ class _PlasmaOptionsState extends State<PlasmaOptions> {
   final GlobalKey<FormState> _qsrAmountKey = GlobalKey();
   final GlobalKey<FormState> _beneficiaryAddressKey = GlobalKey();
   final GlobalKey<LoadingButtonState> _fuseButtonKey = GlobalKey();
-
+  
+  PlasmaBeneficiaryAddressNotifier? _plasmaBeneficiaryAddress;
+  
   int? _maxQsrAmount;
   double? _maxWidth;
 
@@ -69,6 +71,12 @@ class _PlasmaOptionsState extends State<PlasmaOptions> {
   @override
   void initState() {
     super.initState();
+
+    // The setState() causes a redraw which resets the beneficiaryAddress.
+    _plasmaBeneficiaryAddress = Provider.of<PlasmaBeneficiaryAddressNotifier>(context);
+    _plasmaBeneficiaryAddress!.addListener(() => 
+      _beneficiaryAddressController.text = _plasmaBeneficiaryAddress!.getBeneficiaryAddress()!);
+
     sl.get<BalanceBloc>().getBalanceForAllAddresses();
   }
 
@@ -133,112 +141,106 @@ class _PlasmaOptionsState extends State<PlasmaOptions> {
   }
 
   Widget _getWidgetBody(AccountInfo? accountInfo) {
-    return Consumer<PlasmaBeneficiaryAddressNotifier>(
-      builder: (_, notifier, child) {
-        _beneficiaryAddressController.text = notifier.getBeneficiaryAddress()!;
-        return Container(
-          margin: EdgeInsets.all(_marginWidth),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                flex: _beneficiaryAddressExpandedFlex,
-                child: ListView(
-                  shrinkWrap: true,
-                  children: [
-                    DisabledAddressField(
-                      _addressController,
+    return Container(
+      margin: EdgeInsets.all(_marginWidth),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            flex: _beneficiaryAddressExpandedFlex,
+            child: ListView(
+              shrinkWrap: true,
+              children: [
+                DisabledAddressField(
+                  _addressController,
+                  contentLeftPadding: 20.0,
+                ),
+                StepperUtils.getBalanceWidget(kQsrCoin, accountInfo!),
+                Form(
+                  key: _beneficiaryAddressKey,
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
+                  child: InputField(
+                    onChanged: (String value) {
+                      _beneficiaryAddressString.value = value;
+                    },
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(
+                          RegExp(r'[0-9a-z]')),
+                    ],
+                    controller: _beneficiaryAddressController,
+                    hintText: 'Beneficiary address',
+                    contentLeftPadding: 20.0,
+                    validator: (value) =>
+                        InputValidators.checkAddress(value),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(
+            width: _spaceBetweenExpandedWidgets,
+          ),
+          Expanded(
+            flex: _fuseButtonExpandedFlex,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                SizedBox(
+                  height: 87.0,
+                  child: Form(
+                    key: _qsrAmountKey,
+                    autovalidateMode: AutovalidateMode.onUserInteraction,
+                    child: InputField(
+                      enabled: _maxQsrAmount! > 0,
+                      onChanged: (String value) {
+                        setState(() {});
+                      },
+                      inputFormatters:
+                          FormatUtils.getPlasmaAmountTextInputFormatters(
+                        _qsrAmountController.text,
+                      ),
+                      controller: _qsrAmountController,
+                      validator: (value) => InputValidators.correctValue(
+                        value,
+                        _maxQsrAmount,
+                        kQsrCoin.decimals,
+                        min: fuseMinQsrAmount.addDecimals(
+                          qsrDecimals,
+                        ),
+                        canBeEqualToMin: true,
+                      ),
+                      suffixIcon: _getAmountSuffix(),
+                      hintText: 'Amount',
                       contentLeftPadding: 20.0,
                     ),
-                    StepperUtils.getBalanceWidget(kQsrCoin, accountInfo!),
-                    Form(
-                      key: _beneficiaryAddressKey,
-                      autovalidateMode: AutovalidateMode.onUserInteraction,
-                      child: InputField(
-                        onChanged: (String value) {
-                          _beneficiaryAddressString.value = value;
-                        },
-                        inputFormatters: [
-                          FilteringTextInputFormatter.allow(
-                              RegExp(r'[0-9a-z]')),
-                        ],
-                        controller: _beneficiaryAddressController,
-                        hintText: 'Beneficiary address',
-                        contentLeftPadding: 20.0,
-                        validator: (value) =>
-                            InputValidators.checkAddress(value),
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
-              ),
-              SizedBox(
-                width: _spaceBetweenExpandedWidgets,
-              ),
-              Expanded(
-                flex: _fuseButtonExpandedFlex,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    SizedBox(
-                      height: 87.0,
-                      child: Form(
-                        key: _qsrAmountKey,
-                        autovalidateMode: AutovalidateMode.onUserInteraction,
-                        child: InputField(
-                          enabled: _maxQsrAmount! > 0,
-                          onChanged: (String value) {
-                            // The setState() causes a redraw which resets the beneficiaryAddress.
-                            // setState(() {});
-                          },
-                          inputFormatters:
-                              FormatUtils.getPlasmaAmountTextInputFormatters(
-                            _qsrAmountController.text,
-                          ),
-                          controller: _qsrAmountController,
-                          validator: (value) => InputValidators.correctValue(
-                            value,
-                            _maxQsrAmount,
-                            kQsrCoin.decimals,
-                            min: fuseMinQsrAmount.addDecimals(
-                              qsrDecimals,
-                            ),
-                            canBeEqualToMin: true,
-                          ),
-                          suffixIcon: _getAmountSuffix(),
-                          hintText: 'Amount',
-                          contentLeftPadding: 20.0,
-                        ),
-                      ),
-                    ),
-                    ValueListenableBuilder<String>(
-                      valueListenable: _beneficiaryAddressString,
-                      builder: (_, __, ___) {
-                        return Row(
-                          children: [
-                            _getGeneratePlasmaButtonStreamBuilder(),
-                            Visibility(
-                              visible: _isInputValid(),
-                              child: Row(
-                                children: [
-                                  const SizedBox(
-                                    width: 10.0,
-                                  ),
-                                  _getPlasmaIcon(),
-                                ],
+                ValueListenableBuilder<String>(
+                  valueListenable: _beneficiaryAddressString,
+                  builder: (_, __, ___) {
+                    return Row(
+                      children: [
+                        _getGeneratePlasmaButtonStreamBuilder(),
+                        Visibility(
+                          visible: _isInputValid(),
+                          child: Row(
+                            children: [
+                              const SizedBox(
+                                width: 10.0,
                               ),
-                            )
-                          ],
-                        );
-                      },
-                    ),
-                  ],
+                              _getPlasmaIcon(),
+                            ],
+                          ),
+                        )
+                      ],
+                    );
+                  },
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
-        );
-      },
+        ],
+      ),
     );
   }
 
@@ -379,6 +381,7 @@ class _PlasmaOptionsState extends State<PlasmaOptions> {
 
   @override
   void dispose() {
+    _plasmaBeneficiaryAddress!.removeListener(() {});
     _qsrAmountController.dispose();
     _addressController.dispose();
     _beneficiaryAddressController.dispose();


### PR DESCRIPTION
# Problem

There is still an issue where if you enter the beneficiary address, entering the amount resets the beneficiary addy to the original one, and you need to change it again.

# Cause

A widget’s state is stored in a [`State`](https://api.flutter.dev/flutter/widgets/State-class.html) object, separating the widget’s state from its appearance. The state consists of values that can change, like a slider’s current value or whether a checkbox is checked. When the widget’s state changes, the state object calls `setState()`, telling the framework to redraw the widget.

# Solution

Comment out the `setState(() {});` prevents the redraw of the widget.

# Implementation

https://github.com/KingGorrin/syrius/tree/fix-fusing-addr-reset