### PR TITLE
Feature AZ filter on all addresses

### DIFF
--- a/lib/blocs/accelerator/project_list_bloc.dart
+++ b/lib/blocs/accelerator/project_list_bloc.dart
@@ -143,8 +143,8 @@ class ProjectListBloc with RefreshBlocMixin {
 
   /*
   This method filters the projects according to the following rule:
-  if a user doesn't have a Pillar, then we only show him the active
-  projects
+  if a user doesn't have a Pillar, only show the active
+  projects or all owned projects
    */
   Future<List<Project>> _filterProjectsAccordingToPillarInfo(
       Set<Project> projectList) async {
@@ -156,7 +156,7 @@ class ProjectListBloc with RefreshBlocMixin {
           .where(
             (project) =>
                 project.status == AcceleratorProjectStatus.active ||
-                project.owner.toString() == kSelectedAddress,
+                kDefaultAddressList.contains(project.owner.toString()),
           )
           .toList();
       if (activeProjects.isNotEmpty) {


### PR DESCRIPTION
# Problem

A non-pillar user has to switch the selected address to see projects on another address. While a pillar user sees all projects for all addresses.

## Example
An user with 3 addresses
Address 1 has a pillar registration and 3 projects
Address 2 has 1 project
Address 3 has 1 project

- When address 1 is selected, the user sees all 5 projects when activating the 'My projects' filter tag.
- When address 2 or 3 is selected, the user only sees project 1 when activating the 'My projects' filter tag.

# Cause

When address 1 is selected the user is considerd a pillar user, otherwise a non-pillar user.

The 'My projects' filter tag, filters on all user addresses, but as a non-pillar owner the result set gets filtert down in the `_filterProjectsAccordingToPillarInfo` function to all active projects or projects owned by the selected address.

# Solution

With the following change the situation would be equal to that of a pillar user and the user would not have to change the selected address to see all his owned projects.