### PR TITLE
Fixed Y axis for Standard Chart

### DIFF
--- a/lib/widgets/charts/realtime_txs_chart.dart
+++ b/lib/widgets/charts/realtime_txs_chart.dart
@@ -38,7 +38,7 @@ class RealtimeTxsChartState extends State<RealtimeTxsChart> {
     return StandardChart(
       yValuesInterval: (_maxTransactionsPerDay + 1) > kNumOfChartLeftSideTitles
           ? (_maxTransactionsPerDay + 1) / kNumOfChartLeftSideTitles
-          : null,
+          : 1,
       maxY: _maxTransactionsPerDay,
       lineBarsData: _linesBarData(),
       lineBarDotSymbol: 'txs',


### PR DESCRIPTION
Issue
If a selected address had fewer than 10 tx in a given time interval, the Y axis would display duplicated values.
![image](https://user-images.githubusercontent.com/104875699/213527755-c1ab07ae-74d8-4c7c-94bb-9678c6a234b9.png)


With the fix
![image](https://user-images.githubusercontent.com/104875699/213527735-6964a21f-e19f-4784-8a32-a5a778656db2.png)
![image](https://user-images.githubusercontent.com/104875699/213528001-2eafbfe8-8e1a-41f7-ac7a-964755c65007.png)
