### PR TITLE
Fix Get-It dispose

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -322,7 +322,7 @@ class _MyAppState extends State<MyApp> with WindowListener, TrayListener {
     await NodeUtils.closeEmbeddedNode();
     super.onWindowClose();
     deactivate();
-    dispose();
+    await dispose();
     exit(0);
   }
 
@@ -357,9 +357,10 @@ class _MyAppState extends State<MyApp> with WindowListener, TrayListener {
   }
 
   @override
-  void dispose() {
+  Future<void> dispose() async {
     windowManager.removeListener(this);
     trayManager.removeListener(this);
+    await sl.reset();
     super.dispose();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -320,9 +320,10 @@ class _MyAppState extends State<MyApp> with WindowListener, TrayListener {
     sl<Zenon>().wsClient.stop();
     Future.delayed(const Duration(seconds: 60)).then((value) => exit(0));
     await NodeUtils.closeEmbeddedNode();
+    await sl.reset();
     super.onWindowClose();
     deactivate();
-    await dispose();
+    dispose();
     exit(0);
   }
 
@@ -357,10 +358,9 @@ class _MyAppState extends State<MyApp> with WindowListener, TrayListener {
   }
 
   @override
-  Future<void> dispose() async {
+  void dispose() {
     windowManager.removeListener(this);
     trayManager.removeListener(this);
-    await sl.reset();
     super.dispose();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -360,7 +360,6 @@ class _MyAppState extends State<MyApp> with WindowListener, TrayListener {
   void dispose() {
     windowManager.removeListener(this);
     trayManager.removeListener(this);
-    sl.unregister();
     super.dispose();
   }
 }


### PR DESCRIPTION
# Problem

Calling the Get-It Service Locator unregister method within the main dispose method causes an exception when closing the application.

# Cause

According to the [Get-It](https://pub.dev/packages/get_it) package documentation the unregister method is used to unregister an [instance] of an object or a factory/singleton by Type [T] or by name [instanceName]. Not supplying an Type [T] or name causes the exception.

The reset method should be used to fully dispose the Service Locator. The reset method is asynchronous and cannot be used in the dispose method.

# Solution

Prevent the exception from occuring by removing the method call. 