### PR TITLE
Fix Realtime y-axis

### DIFF
--- a/lib/widgets/charts/realtime_txs_chart.dart
+++ b/lib/widgets/charts/realtime_txs_chart.dart
@@ -36,8 +36,8 @@ class RealtimeTxsChartState extends State<RealtimeTxsChart> {
   @override
   Widget build(BuildContext context) {
     return StandardChart(
-      yValuesInterval: (_maxTransactionsPerDay + 1) > kNumOfChartLeftSideTitles
-          ? (_maxTransactionsPerDay + 1) / kNumOfChartLeftSideTitles
+      yValuesInterval: _maxTransactionsPerDay > kNumOfChartLeftSideTitles
+          ? _maxTransactionsPerDay / kNumOfChartLeftSideTitles
           : 1,
       maxY: _maxTransactionsPerDay,
       lineBarsData: _linesBarData(),


### PR DESCRIPTION
# Problem

The y axis interval values for the StandardChart sometimes overlaps with the second value.

# Cause

The y axis uses a default chart title length of 10. The y axis interval value does not match when the total number of tx's of the day is greater than 10. 

# Solution

Use a non zero-based calculation when determining the y axis interval value.