### PR TITLE
Create git metadata on Windows build

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -118,3 +118,7 @@ foreach(znn_library ${SYRIUS_LIBRARIES})
     COMPONENT Runtime)
   message(STATUS "Copy ZNN library: \"${znn_library}\"")
 endforeach(znn_library)
+
+find_program(POWERSHELL_PATH NAMES powershell)
+add_custom_target("git_metadata" ALL
+  COMMAND ${POWERSHELL_PATH} "${CMAKE_HOME_DIRECTORY}/CreateGitMetadata.ps1")

--- a/windows/CreateGitMetadata.ps1
+++ b/windows/CreateGitMetadata.ps1
@@ -1,0 +1,14 @@
+$GIT_BRANCH_NAME = git rev-parse --abbrev-ref HEAD
+$GIT_COMMIT_HASH = git rev-parse HEAD
+$GIT_COMMIT_MESSAGE = git log -1 --pretty=%s
+$GIT_COMMIT_DATE = git --no-pager log -1 --format="%ai"
+$GIT_ORIGIN_URL = git config --get remote.origin.url
+$GIT_COMMIT_FILE = "${PSScriptRoot}\..\lib\utils\metadata.dart"
+
+Clear-Content $GIT_COMMIT_FILE -Force
+
+Add-Content $GIT_COMMIT_FILE "const String gitBranchName = '$GIT_BRANCH_NAME';"
+Add-Content $GIT_COMMIT_FILE "const String gitCommitHash = '$GIT_COMMIT_HASH';"
+Add-Content $GIT_COMMIT_FILE "const String gitCommitMessage = '$GIT_COMMIT_MESSAGE';"
+Add-Content $GIT_COMMIT_FILE "const String gitCommitDate = '$GIT_COMMIT_DATE';"
+Add-Content $GIT_COMMIT_FILE "const String gitOriginUrl = '$GIT_ORIGIN_URL';"


### PR DESCRIPTION
# What?

Adds git metadata to the `lib\utils\metadata.dart` file when building for Windows.

# Why?

Adding the git metadata to the `lib\utils\metadata.dart` file makes it available within syrius.

# How?

The `windows/CMakeLists.txt` file has a custom target `git_metadata` which always executes the `windows/CreateGitMetadata.ps1` Powershell script when building for Windows.

The `windows/CreateGitMetadata.ps1` Powershell script executes git commands and populates the following variables:

- `GIT_BRANCH_NAME`
- `GIT_COMMIT_HASH`
- `GIT_COMMIT_MESSAGE`
- `GIT_COMMIT_DATE`
- `GIT_ORIGIN_URL`
- `GIT_COMMIT_FILE`

The results are written to the `lib\utils\metadata.dart` file.