### PR TITLE
Create git metadata on Linux build

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -169,3 +169,9 @@ foreach(znn_library ${SYRIUS_LIBRARIES})
     COMPONENT Runtime)
   message(STATUS "Copy ZNN library: \"${znn_library}\"")
 endforeach(znn_library)
+
+add_custom_target(
+  "git_metadata" ALL
+  COMMAND "${CMAKE_HOME_DIRECTORY}/create-git-metadata.sh"
+  WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}
+)

--- a/linux/create-git-metadata.sh
+++ b/linux/create-git-metadata.sh
@@ -1,0 +1,14 @@
+GIT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+GIT_COMMIT_HASH=$(git rev-parse HEAD)
+GIT_COMMIT_MESSAGE=$(git log -1 --pretty=%s)
+GIT_COMMIT_DATE=$(git --no-pager log -1 --format="%ai")
+GIT_ORIGIN_URL=$(git config --get remote.origin.url)
+GIT_COMMIT_FILE="../lib/utils/metadata.dart"
+
+sed --i '1,5d' $GIT_COMMIT_FILE
+
+echo "const String gitBranchName = '$GIT_BRANCH_NAME';" >> $GIT_COMMIT_FILE
+echo "const String gitCommitHash = '$GIT_COMMIT_HASH';" >> $GIT_COMMIT_FILE
+echo "const String gitCommitMessage = '$GIT_COMMIT_MESSAGE';" >> $GIT_COMMIT_FILE
+echo "const String gitCommitDate = '$GIT_COMMIT_DATE';" >> $GIT_COMMIT_FILE
+echo "const String gitOriginUrl = '$GIT_ORIGIN_URL';" >> $GIT_COMMIT_FILE


### PR DESCRIPTION
# What?

Adds git metadata to the `lib\utils\metadata.dart` file when building for Linux.

# Why?

Adding the git metadata to the `lib\utils\metadata.dart` file makes it available within syrius.

# How?

The `linux/CMakeLists.txt` file has a custom target `git_metadata` which always executes the `linux/create-git-metadata.sh` shell script when building for Linux.

The `linux/create-git-metadata.sh` shell script executes git commands and populates the following variables:

- `GIT_BRANCH_NAME`
- `GIT_COMMIT_HASH`
- `GIT_COMMIT_MESSAGE`
- `GIT_COMMIT_DATE`
- `GIT_ORIGIN_URL`
- `GIT_COMMIT_FILE`

The results are written to the `lib\utils\metadata.dart` file.