### PR TITLE
Fix context menu

### DIFF
--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -139,6 +139,7 @@ class AppTheme {
     scaffoldBackgroundColor: AppColors.backgroundLight,
     textSelectionTheme: const TextSelectionThemeData(
       cursorColor: AppColors.znnColor,
+      selectionHandleColor: AppColors.znnColor,
     ),
     fontFamily: 'Roboto',
     inputDecorationTheme: InputDecorationTheme(
@@ -276,6 +277,7 @@ class AppTheme {
     textSelectionTheme: TextSelectionThemeData(
       selectionColor: Colors.white.withOpacity(0.1),
       cursorColor: AppColors.znnColor,
+      selectionHandleColor: AppColors.znnColor,
     ),
     fontFamily: 'Roboto',
     inputDecorationTheme: InputDecorationTheme(

--- a/lib/widgets/reusable_widgets/input_fields/input_field.dart
+++ b/lib/widgets/reusable_widgets/input_fields/input_field.dart
@@ -64,6 +64,26 @@ class _InputFieldState extends State<InputField> {
   @override
   Widget build(BuildContext context) {
     return TextFormField(
+      contextMenuBuilder: (context, editableTextState) {
+        return AdaptiveTextSelectionToolbar(
+            anchors: editableTextState.contextMenuAnchors,
+            children: editableTextState.contextMenuButtonItems
+                .map((ContextMenuButtonItem buttonItem) {
+              return Row(children: [
+                Expanded(
+                    child: TextButton(
+                  onPressed: buttonItem.onPressed,
+                  style: TextButton.styleFrom(
+                    shape: const RoundedRectangleBorder(),
+                  ),
+                  child: Text(
+                      AdaptiveTextSelectionToolbar.getButtonLabel(
+                          context, buttonItem),
+                      style: const TextStyle(color: Colors.white)),
+                ))
+              ]);
+            }).toList());
+      },
       maxLines: widget.maxLines,
       obscureText: widget.obscureText,
       onChanged: widget.onChanged,


### PR DESCRIPTION
# Problem

The right-click menu options should be in a row, not a column.

# Cause

Syrius uses the default `contextMenuBuilder` for the TextFormField widgets. It controls the default copy/paste/cut/select all buttons for the platform. For example, under the Plasma tab when selecting the beneficiary address text and right clicking it.

The context menu was horizontally orientated, but after using flutter 3.7.0 the buttons are now stacked vertically, showing black at both sides because the context menu is larger than the width of the buttons in it. 

Besides the change in the context menu, the selection handles when selecting text are not green anymore.

# Solution

I could not find a solution to change the orientation of the button items in the context menu, but did manage to style it accordingly by explicitly setting a `contextMenuBuilder` on the `InputField` widget.

The context menu button items are now stacked vertically, using the complete width of the menu.

The `selectionHandleColor` is added to the AppTheme. The property controls the handle color of the selection handles. More info on this can be found at: https://docs.flutter.dev/release/breaking-changes/text-selection-theme