### PR TITLE
Fix fusing address select

### DIFF
--- a/lib/utils/notifiers/plasma_beneficiary_address_notifier.dart
+++ b/lib/utils/notifiers/plasma_beneficiary_address_notifier.dart
@@ -5,10 +5,8 @@ class PlasmaBeneficiaryAddressNotifier extends ChangeNotifier {
   String? _plasmaBeneficiaryAddress = kSelectedAddress;
 
   changePlasmaBeneficiaryAddress(String? newAddress) {
-    if (_plasmaBeneficiaryAddress != newAddress) {
-      _plasmaBeneficiaryAddress = newAddress;
-      notifyListeners();
-    }
+    _plasmaBeneficiaryAddress = newAddress;
+    notifyListeners();
   }
 
   String? getBeneficiaryAddress() => _plasmaBeneficiaryAddress;


### PR DESCRIPTION
# Problem

Both the `PlasmaBeneficiaryAddressNotifier` and `SelectedAddressNotifier` get initialized with the default address when syrius starts. Selecting the default address for the beneficiary address under the Plasma tab won't cause a change and subsequently the listeners will not get notified of the selected address.

This problem was less apparent before the [Plasma Reset Bug Fix](https://github.com/alienc0der/syrius/pull/18), because the address was always initialized when the Plasma was loaded. However, the problem is still present even without the [Plasma Reset Bug Fix](https://github.com/alienc0der/syrius/pull/18). For example, when selecting an address from the list, removing or changing the beneficiary address and selecting the same address again, will not change it.

# Cause

Unlike the `SelectedAddressNotifier` the `PlasmaBeneficiaryAddressNotifier` only notifies its listeners when the address changes. This introduces a problem when selecting the beneficiary address under the Plasma tab.

# Solution

Change the `PlasmaBeneficiaryAddressNotifier` to always notify its listeners when the `changeBeneficieryAddress` is called.